### PR TITLE
Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 This site houses data and code uploaded by authors for papers published in the journal.
 
-[Details](index.md)
+[Click Here for Details](index.md)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+[INFORMS Journal on Computing](https://pubsonline.informs.org/journal/ijoc)
+
+This site houses data and code uploaded by authors for papers published in the journal.
+
+[Details](index.md)


### PR DESCRIPTION
When one follows a link to the github page as, e.g., Alice just suggested in an email, one does not see the index displayed on the screen. This is one way to deal with that. If there are better ways, of course just delete this PR.